### PR TITLE
Add bash completion

### DIFF
--- a/qubes.bash.completion
+++ b/qubes.bash.completion
@@ -1,0 +1,5 @@
+PASSWORD_STORE_EXTENSION_COMMANDS+=(qubes)
+
+__password_store_extension_complete_qubes() {
+    _pass_complete_entries 1
+}


### PR DESCRIPTION
This should work by adding the script into `~/.bash_completion`, or putting the script in `<password_store_dir>/.extensions/qubes.bash.completion` and import it with `source`.